### PR TITLE
fix: RIO score shows incorrect gains in solo

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -26,7 +26,6 @@ local defaults = {
         showTooltips = true,
         weightByScore = true, -- #20: factor M+ score into recommendations (legacy, kept for compat)
         upgradeScoring = true, -- #43: factor ilvl upgrades into scoring
-        targetKeyLevel = 10, -- #43: fallback target M+ key level
         offSpec = nil, -- off-spec key (e.g. "WARRIOR_FURY"), nil if disabled
         activeTab = "mplus", -- "mplus" or "raid" (legacy alias for activeMode)
         -- V4: new scoring weights
@@ -242,6 +241,8 @@ function DungeonOptimizer:OnEnable()
     self:RegisterEvent("CHALLENGE_MODE_COMPLETED")
     -- #27: affix updates
     self:RegisterEvent("MYTHIC_PLUS_CURRENT_AFFIX_UPDATE")
+    -- M+ data refresh (fires when season best / map info becomes available)
+    self:RegisterEvent("CHALLENGE_MODE_MAPS_UPDATE")
 
 
     -- Roadmap: recompute when gear or currency changes
@@ -282,6 +283,14 @@ function DungeonOptimizer:OnEnable()
     -- #27: Request current affixes
     if C_MythicPlus and C_MythicPlus.RequestCurrentAffixes then
         C_MythicPlus.RequestCurrentAffixes()
+    end
+    -- Request M+ map info so GetSeasonBestForMap() returns data in solo
+    if C_MythicPlus and C_MythicPlus.RequestMapInfo then
+        C_MythicPlus.RequestMapInfo()
+    end
+    -- Clean up orphaned targetKeyLevel saved variable (UI removed in v4)
+    if self.db.profile.targetKeyLevel ~= nil then
+        self.db.profile.targetKeyLevel = nil
     end
 end
 
@@ -413,6 +422,13 @@ function DungeonOptimizer:CHALLENGE_MODE_COMPLETED()
         self:RecalculateAllRankings()
         NS.UI:Show()
     end
+end
+
+-- M+ data available (fires after RequestMapInfo or when dungeon list changes)
+function DungeonOptimizer:CHALLENGE_MODE_MAPS_UPDATE()
+    self:BuildDynamicDungeonList()
+    self:RecalculateAllRankings()
+    if NS.UI then NS.UI:RefreshIfVisible() end
 end
 
 -- #27: Affix update
@@ -722,7 +738,7 @@ function DungeonOptimizer:GetRewardIlvlForKey(keyLevel)
 end
 
 -- ============================================================================
--- #43: TARGET KEY LEVEL (auto from party keys, fallback to saved setting)
+-- #43: TARGET KEY LEVEL (auto from party keys, fallback to season best + 1)
 -- ============================================================================
 function DungeonOptimizer:GetTargetKeyLevel(dungeonKey)
     -- Check party keystones for this dungeon
@@ -744,7 +760,19 @@ function DungeonOptimizer:GetTargetKeyLevel(dungeonKey)
             end
         end
     end
-    return self.db.profile.targetKeyLevel or 10
+    -- Fallback: season best + 1 for this dungeon, or 10 if never done
+    if dungeonKey and NS.CHALLENGE_MODE_MAP then
+        for mapID, dk in pairs(NS.CHALLENGE_MODE_MAP) do
+            if dk == dungeonKey then
+                local scoreData = self:GetDungeonScoreData(mapID)
+                if scoreData and scoreData.seasonBest and scoreData.seasonBest.level then
+                    return scoreData.seasonBest.level + 1
+                end
+                break
+            end
+        end
+    end
+    return 10
 end
 
 -- ============================================================================

--- a/DungeonOptimizer.toc
+++ b/DungeonOptimizer.toc
@@ -3,7 +3,7 @@
 ## Notes: M+ dashboard: ranks dungeons by gear upgrades + RIO score gains for your group.
 ## Notes-frFR: Dashboard M+ : classe les donjons par upgrades de stuff + gains de score RIO pour votre groupe.
 ## Author: BIS-Group
-## Version: 4.3.4
+## Version: 4.3.5
 ## SavedVariables: DungeonOptimizerDB
 ## Category: Dungeons
 ## IconTexture: Interface\Icons\INV_Misc_Map_01

--- a/DungeonOptimizer_Mainline.toc
+++ b/DungeonOptimizer_Mainline.toc
@@ -3,7 +3,7 @@
 ## Notes: M+ dashboard: ranks dungeons by gear upgrades + RIO score gains for your group.
 ## Notes-frFR: Dashboard M+ : classe les donjons par upgrades de stuff + gains de score RIO pour votre groupe.
 ## Author: BIS-Group
-## Version: 4.3.4
+## Version: 4.3.5
 ## SavedVariables: DungeonOptimizerDB
 ## Category: Dungeons
 ## IconTexture: Interface\Icons\INV_Misc_Map_01

--- a/tests/core_spec.lua
+++ b/tests/core_spec.lua
@@ -1947,9 +1947,19 @@ describe("GetTargetKeyLevel", function()
     end)
     after_each(stub.resetStubs)
 
-    it("returns saved setting as fallback", function()
-        Core.db.profile.targetKeyLevel = 12
+    it("returns season best + 1 as fallback when dungeon has been done", function()
+        _G.C_MythicPlus.GetSeasonBestForMap = function(mapID)
+            if mapID == 2773 then
+                return { level = 11, dungeonScore = 135 }, nil
+            end
+            return nil, nil
+        end
         assert.are.equal(12, Core:GetTargetKeyLevel("MAGISTER"))
+    end)
+
+    it("returns 10 as fallback when dungeon has never been done", function()
+        _G.C_MythicPlus.GetSeasonBestForMap = function() return nil, nil end
+        assert.are.equal(10, Core:GetTargetKeyLevel("MAGISTER"))
     end)
 
     it("returns party keystone level when available", function()
@@ -1959,8 +1969,13 @@ describe("GetTargetKeyLevel", function()
         assert.are.equal(15, Core:GetTargetKeyLevel("MAGISTER"))
     end)
 
-    it("returns fallback when party key is for different dungeon", function()
-        Core.db.profile.targetKeyLevel = 8
+    it("returns season best + 1 when party key is for different dungeon", function()
+        _G.C_MythicPlus.GetSeasonBestForMap = function(mapID)
+            if mapID == 2773 then
+                return { level = 7, dungeonScore = 100 }, nil
+            end
+            return nil, nil
+        end
         NS.partyKeystones = {
             ["Friend-Realm"] = { mapID = 2774, level = 15 },
         }


### PR DESCRIPTION
## Summary

Fixes two bugs that caused the RIO score simulation to show wildly incorrect gains when playing solo:

- **Missing M+ data request**: The addon never called `C_MythicPlus.RequestMapInfo()` at login, so `GetSeasonBestForMap()` returned nil in solo. All dungeons appeared as never completed, inflating the projected RIO gain to the full score instead of the delta.
- **Orphaned `targetKeyLevel` saved variable**: The UI slider was removed in v4 (commit 391da8b) but the saved variable persisted. Players who had changed the value were stuck with a hidden, non-modifiable fallback (e.g., +9 instead of +10).

**Changes:**
- Call `RequestMapInfo()` on login so M+ season best data is available in solo
- Register `CHALLENGE_MODE_MAPS_UPDATE` event to refresh rankings when data arrives
- Replace fixed `targetKeyLevel` fallback with automatic **season best + 1** logic
- Clean up orphaned `targetKeyLevel` from saved variables on login
- Remove `targetKeyLevel` from profile defaults

## Pre-Landing Review

No issues found.

## Plan Completion

7/7 plan items implemented.

## Test plan

- [x] All 319 Busted tests pass (0 failures)
- [x] Updated GetTargetKeyLevel tests for new season best + 1 fallback
- [ ] Verify in-game: solo with a timed +11 Nexus should simulate +12 (not full score)

🤖 Generated with [Claude Code](https://claude.com/claude-code)